### PR TITLE
Adding flags for more customable parameter.

### DIFF
--- a/src/skymin/CommandLib/BaseCommand.php
+++ b/src/skymin/CommandLib/BaseCommand.php
@@ -25,11 +25,11 @@ declare(strict_types = 1);
 
 namespace skymin\CommandLib;
 
-use pocketmine\player\Player;
 use pocketmine\command\Command;
 use pocketmine\lang\Translatable;
-use pocketmine\permission\PermissionManager;
 use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
+use pocketmine\permission\PermissionManager;
+use pocketmine\player\Player;
 
 use function explode;
 use function array_values;
@@ -58,16 +58,15 @@ abstract class BaseCommand extends Command{
 	}
 	
 	final public function hasOverloads() : bool{
-		if($this->overloads === []){
-			return false;
-		}
-		return true;
+		return $this->overloads !== [];
 	}
 	
 	final public function getOverloads(Player $player) : array{
 		$overloads = $this->overloads;
 		foreach($this->overPermission as $key => $value){
-			if(!isset($overloads[$key])) continue;
+			if(!isset($overloads[$key])) {
+				continue;
+			}
 			if(!$player->hasPermission($value)){
 				unset($overloads[$key]);
 			}

--- a/src/skymin/CommandLib/CmdManager.php
+++ b/src/skymin/CommandLib/CmdManager.php
@@ -26,34 +26,37 @@ declare(strict_types = 1);
 namespace skymin\CommandLib;
 
 use pocketmine\Server;
-use pocketmine\player\Player;
-use pocketmine\plugin\Plugin;
 use pocketmine\event\EventPriority;
 use pocketmine\event\server\DataPacketSendEvent;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+use pocketmine\player\Player;
+use pocketmine\plugin\Plugin;
 
 final class CmdManager{
 	
 	private static bool $registerBool= false;
 	
 	public static function register(Plugin $plugin) : void{
-		if(!self::$registerBool){
-			Server::getInstance()->getPluginManager()->registerEvent(DataPacketSendEvent::class, function(DataPacketSendEvent $ev) : void{
-				foreach ($ev->getTargets() as $target){
-					$player = $target->getPlayer();
-					foreach($ev->getPackets() as $packet){
-						if(!$packet instanceof AvailableCommandsPacket) continue;
-						foreach($packet->commandData as $name => $commandData){
-							$cmd = Server::getInstance()->getCommandMap()->getCommand($name);
-							if($cmd instanceof BaseCommand && $cmd->hasOverloads()){
-								$commandData->overloads = $cmd->getOverloads($player);
-							}
+		if (self::$registerBool) {
+			return;
+		}
+		Server::getInstance()->getPluginManager()->registerEvent(DataPacketSendEvent::class, function(DataPacketSendEvent $ev) : void{
+			foreach ($ev->getTargets() as $target) {
+				$player = $target->getPlayer();
+				foreach ($ev->getPackets() as $packet) {
+					if (!$packet instanceof AvailableCommandsPacket) {
+						continue;
+					}
+					foreach ($packet->commandData as $name => $commandData) {
+						$cmd = Server::getInstance()->getCommandMap()->getCommand($name);
+						if ($cmd instanceof BaseCommand && $cmd->hasOverloads()) {
+							$commandData->overloads = $cmd->getOverloads($player);
 						}
 					}
 				}
-			}, EventPriority::MONITOR, $plugin);
-			self::$registerBool = true;
-		}
+			}
+		}, EventPriority::MONITOR, $plugin);
+		self::$registerBool = true;
 	}
 	
 	public static function isRegister() : bool{

--- a/src/skymin/CommandLib/EnumFactory.php
+++ b/src/skymin/CommandLib/EnumFactory.php
@@ -25,27 +25,20 @@ declare(strict_types = 1);
 
 namespace skymin\CommandLib;
 
-use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
-use pocketmine\network\mcpe\protocol\types\command\{CommandParameter, CommandEnum};
+use pocketmine\network\mcpe\protocol\types\command\{CommandEnum, CommandParameter};
 
 final class EnumFactory{
+	public const FLAG_FORCE_COLLAPSE_ENUM = 0x0; //Somehow in pmmp source code, this ís 0x1 which is 1 while the default flag is 0
+	public const FLAG_HAS_ENUM_CONSTRAINT = 0x1; //This is 0x2 in pmmp, I tried to make a CommandParameter with this but resulted in a broken command
 	
-	public static function create(string $name, string|EnumType $enumType, ?array $enumValues = null, bool $optional = false) : CommandParameter{
-		$result = new CommandParameter();
-		$result->paramName = $name;
-		$result->flags = 0;
-		$result->isOptional = $optional;
-		$result->paramType = AvailableCommandsPacket::ARG_FLAG_VALID;
+	public static function create(string $name, string|EnumType $enumType, ?array $enumValues = null, int $flag = self::FLAG_FORCE_COLLAPSE_ENUM, bool $optional = false) : CommandParameter{
 		if($enumType instanceof EnumType){
 			if($enumValues === null){
-				$result->paramType |= $enumType->getParamType();
-				return $result;
+				return CommandParameter::standard($name, $enumType->getParamType(), $flag, $optional);
 			}
 			$enumType = $enumType->name();
 		}
-		$result->paramType |= AvailableCommandsPacket::ARG_FLAG_ENUM;
-		$result->enum = new CommandEnum($enumType, $enumValues) ;
-		return $result;
+		return CommandParameter::enum($name, new CommandEnum($enumType, $enumValues), $flag, $optional);
 	}
 	
 }

--- a/src/skymin/CommandLib/EnumType.php
+++ b/src/skymin/CommandLib/EnumType.php
@@ -25,8 +25,8 @@ declare(strict_types = 1);
 
 namespace skymin\CommandLib;
 
-use pocketmine\utils\EnumTrait;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket as Type;
+use pocketmine\utils\EnumTrait;
 
 /**
  * @method static self INT()
@@ -37,7 +37,7 @@ use pocketmine\network\mcpe\protocol\AvailableCommandsPacket as Type;
  * @method static self MESSAGE()
  * @method static self JSON()
  * @method static self FILE()
- * @method staric self XP()
+ * @method static self XP()
  */
 final class EnumType{
 	use EnumTrait{


### PR DESCRIPTION
Hello, I made some changes to the code so that it can construct type 1 parameters, which you can test with your test plugin by typing "/test [player] <t:e:s:t>". I also changed some other things to make the code easier to read and edit (mostly for shorting it).